### PR TITLE
chore: update release please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -25,42 +25,42 @@
         },
         {
             "type": "docs",
-            "hidden": true,
+            "hidden": false,
             "section": "Docs"
         },
         {
             "type": "chore",
-            "hidden": true,
+            "hidden": false,
             "section": "Other"
         },
         {
             "type": "build",
-            "hidden": true,
+            "hidden": false,
             "section": "Build"
         },
         {
             "type": "deps",
-            "hidden": true,
+            "hidden": false,
             "section": "Dependency Updates"
         },
         {
             "type": "ci",
-            "hidden": true,
+            "hidden": false,
             "section": "CI"
         },
         {
             "type": "refactor",
-            "hidden": true,
+            "hidden": false,
             "section": "Refactoring"
         },
         {
             "type": "style",
-            "hidden": true,
+            "hidden": false,
             "section": "Code Style"
         },
         {
             "type": "test",
-            "hidden": true,
+            "hidden": false,
             "section": "Tests"
         }
     ]


### PR DESCRIPTION
This PR does 2 things: 

 1. Updates the release please config to not hide any conventional commit types
 2. Reverts the manual version bump added in #5 which was unnecessary