### PR TITLE
ci: fix pyproject.toml build information

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [project]
 name = "openfeature-provider-flagsmith"
-version = "0.1.0"
 description = "Openfeature provider for Flagsmith"
 authors = [
     { name = "Matthew Elwell", email = "matthew.elwell@flagsmith.com>" }
@@ -15,6 +14,7 @@ dependencies = [
 [tool.poetry]
 requires-poetry = ">=2.0"
 packages = [{ include = "openfeature_flagsmith" }]
+version = "0.1.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0.2"


### PR DESCRIPTION
Move version and packages back to `[tool.poetry]` to: 

 1. Fix build (see previous failure [here](https://github.com/Flagsmith/flagsmith-openfeature-provider-python/actions/runs/15351657532))
 2. Fix release please not updating the version (see previous PR [here](https://github.com/Flagsmith/flagsmith-openfeature-provider-python/pull/8))