### PR TITLE
ci: fix release please

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [project]
 name = "openfeature-provider-flagsmith"
+version = "0.1.1"
 description = "Openfeature provider for Flagsmith"
 authors = [
     { name = "Matthew Elwell", email = "matthew.elwell@flagsmith.com>" }
@@ -14,7 +15,6 @@ dependencies = [
 [tool.poetry]
 requires-poetry = ">=2.0"
 packages = [{ include = "openfeature_flagsmith" }]
-version = "0.1.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0.2"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,7 @@
     "bootstrap-sha": "374e83b797fbc644ce1e5e3d14ac7acce3a9b44f",
     "packages": {
         ".": {
-            "release-type": "simple",
+            "release-type": "python",
             "changelog-path": "CHANGELOG.md",
             "bump-minor-pre-major": false,
             "bump-patch-for-minor-pre-major": false,


### PR DESCRIPTION
This PR should resolve the issue with release please not updating the version of the package in pyproject.toml.

The main change in this PR is to update the release type from simple -> python and in doin so, we can move the `version` attribute back to the generic `[project]` section in `pyproject.toml`. 