### PR TITLE
fix: revert evaluation context change

### DIFF
--- a/openfeature_flagsmith/provider.py
+++ b/openfeature_flagsmith/provider.py
@@ -47,7 +47,9 @@ class FlagsmithProvider(AbstractProvider):
         default_value: bool,
         evaluation_context: EvaluationContext = EvaluationContext(),
     ) -> FlagResolutionDetails[bool]:
-        return self._resolve(flag_key, FlagType.BOOLEAN, default_value, evaluation_context)
+        return self._resolve(
+            flag_key, FlagType.BOOLEAN, default_value, evaluation_context
+        )
 
     def resolve_string_details(
         self,
@@ -55,7 +57,9 @@ class FlagsmithProvider(AbstractProvider):
         default_value: str,
         evaluation_context: EvaluationContext = EvaluationContext(),
     ) -> FlagResolutionDetails[str]:
-        return self._resolve(flag_key, FlagType.STRING, default_value, evaluation_context)
+        return self._resolve(
+            flag_key, FlagType.STRING, default_value, evaluation_context
+        )
 
     def resolve_integer_details(
         self,
@@ -63,7 +67,9 @@ class FlagsmithProvider(AbstractProvider):
         default_value: int,
         evaluation_context: EvaluationContext = EvaluationContext(),
     ) -> FlagResolutionDetails[int]:
-        return self._resolve(flag_key, FlagType.INTEGER, default_value, evaluation_context)
+        return self._resolve(
+            flag_key, FlagType.INTEGER, default_value, evaluation_context
+        )
 
     def resolve_float_details(
         self,
@@ -71,7 +77,9 @@ class FlagsmithProvider(AbstractProvider):
         default_value: float,
         evaluation_context: EvaluationContext = EvaluationContext(),
     ) -> FlagResolutionDetails[float]:
-        return self._resolve(flag_key, FlagType.FLOAT, default_value, evaluation_context)
+        return self._resolve(
+            flag_key, FlagType.FLOAT, default_value, evaluation_context
+        )
 
     def resolve_object_details(
         self,
@@ -79,7 +87,9 @@ class FlagsmithProvider(AbstractProvider):
         default_value: typing.Union[dict, list],
         evaluation_context: EvaluationContext = EvaluationContext(),
     ) -> FlagResolutionDetails[typing.Union[dict, list]]:
-        return self._resolve(flag_key, FlagType.OBJECT, default_value, evaluation_context)
+        return self._resolve(
+            flag_key, FlagType.OBJECT, default_value, evaluation_context
+        )
 
     def _resolve(
         self,

--- a/openfeature_flagsmith/provider.py
+++ b/openfeature_flagsmith/provider.py
@@ -45,51 +45,51 @@ class FlagsmithProvider(AbstractProvider):
         self,
         flag_key: str,
         default_value: bool,
-        context: EvaluationContext = EvaluationContext(),
+        evaluation_context: EvaluationContext = EvaluationContext(),
     ) -> FlagResolutionDetails[bool]:
-        return self._resolve(flag_key, FlagType.BOOLEAN, default_value, context)
+        return self._resolve(flag_key, FlagType.BOOLEAN, default_value, evaluation_context)
 
     def resolve_string_details(
         self,
         flag_key: str,
         default_value: str,
-        context: EvaluationContext = EvaluationContext(),
+        evaluation_context: EvaluationContext = EvaluationContext(),
     ) -> FlagResolutionDetails[str]:
-        return self._resolve(flag_key, FlagType.STRING, default_value, context)
+        return self._resolve(flag_key, FlagType.STRING, default_value, evaluation_context)
 
     def resolve_integer_details(
         self,
         flag_key: str,
         default_value: int,
-        context: EvaluationContext = EvaluationContext(),
+        evaluation_context: EvaluationContext = EvaluationContext(),
     ) -> FlagResolutionDetails[int]:
-        return self._resolve(flag_key, FlagType.INTEGER, default_value, context)
+        return self._resolve(flag_key, FlagType.INTEGER, default_value, evaluation_context)
 
     def resolve_float_details(
         self,
         flag_key: str,
         default_value: float,
-        context: EvaluationContext = EvaluationContext(),
+        evaluation_context: EvaluationContext = EvaluationContext(),
     ) -> FlagResolutionDetails[float]:
-        return self._resolve(flag_key, FlagType.FLOAT, default_value, context)
+        return self._resolve(flag_key, FlagType.FLOAT, default_value, evaluation_context)
 
     def resolve_object_details(
         self,
         flag_key: str,
         default_value: typing.Union[dict, list],
-        context: EvaluationContext = EvaluationContext(),
+        evaluation_context: EvaluationContext = EvaluationContext(),
     ) -> FlagResolutionDetails[typing.Union[dict, list]]:
-        return self._resolve(flag_key, FlagType.OBJECT, default_value, context)
+        return self._resolve(flag_key, FlagType.OBJECT, default_value, evaluation_context)
 
     def _resolve(
         self,
         flag_key: str,
         flag_type: FlagType,
         default_value: typing.Any,
-        context: EvaluationContext,
+        evaluation_context: EvaluationContext,
     ) -> FlagResolutionDetails:
         try:
-            flag = self._get_flags(context).get_flag(flag_key)
+            flag = self._get_flags(evaluation_context).get_flag(flag_key)
         except FlagsmithClientError as e:
             raise FlagsmithProviderError(
                 error_code=ErrorCode.GENERAL,
@@ -123,10 +123,10 @@ class FlagsmithProvider(AbstractProvider):
             % (flag_key, flag_type.value)
         )
 
-    def _get_flags(self, context: EvaluationContext = EvaluationContext()):
-        if targeting_key := context.targeting_key:
+    def _get_flags(self, evaluation_context: EvaluationContext = EvaluationContext()):
+        if targeting_key := evaluation_context.targeting_key:
             return self._client.get_identity_flags(
                 identifier=targeting_key,
-                traits=context.attributes.get("traits", {}),
+                traits=evaluation_context.attributes.get("traits", {}),
             )
         return self._client.get_environment_flags()

--- a/poetry.lock
+++ b/poetry.lock
@@ -734,4 +734,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0"
-content-hash = "d00ad996917b217d9972d2e3bbefe6a69d82a1355428071c090c81bb0cdfef3b"
+content-hash = "e8b42ffd80c071e498398f6561b582cb9799dfb9b2f9810f84dbb4891a6d3324"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 requires-python = ">=3.9,<4.0"
 dependencies = [
     "flagsmith (>=3.6.0,<4.0.0)",
-    "openfeature-sdk (>=0.6.0,<1.0.0)",
+    "openfeature-sdk (>=0.6.0,<0.9.0)",
 ]
 
 [tool.poetry]

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -304,7 +304,7 @@ def test_identity_flags_are_used_if_targeting_key_provided(
     result = provider.resolve_string_details(
         flag_key=key,
         default_value=default_value,
-        context=EvaluationContext(
+        evaluation_context=EvaluationContext(
             targeting_key=targeting_key, attributes={"traits": traits}
         ),
     )


### PR DESCRIPTION
Turns out that the openfeature SDK only updated to match certain parts of the method signature defined in the specification. 

I have now tested this manually to confirm that it works as expected in the hope that this will be the last PR in this series... 