### PR TITLE
fix: `FlagNotFound` not raised for non-existing features

### DIFF
--- a/openfeature_flagsmith/provider.py
+++ b/openfeature_flagsmith/provider.py
@@ -2,7 +2,10 @@ import json
 import typing
 from json import JSONDecodeError
 
-from flagsmith.exceptions import FlagsmithClientError
+from flagsmith.exceptions import (
+    FlagsmithClientError,
+    FlagsmithFeatureDoesNotExistError,
+)
 from flagsmith.flagsmith import Flagsmith
 from openfeature.evaluation_context import EvaluationContext
 from openfeature.exception import (
@@ -154,6 +157,10 @@ class FlagsmithProvider(AbstractProvider):
     ) -> FlagResolutionDetails:
         try:
             flag = self._get_flags(evaluation_context).get_flag(flag_key)
+        except FlagsmithFeatureDoesNotExistError as e:
+            raise FlagNotFoundError(
+                error_message="Flag '%s' was not found." % flag_key
+            ) from e
         except FlagsmithClientError as e:
             raise FlagsmithProviderError(
                 error_code=ErrorCode.GENERAL,

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -284,6 +284,25 @@ def test_resolve_string_details_when_flagsmith_error(
     )
 
 
+def test_resolve_string_details_when_feature_does_not_exist(
+    mock_flagsmith_client: MagicMock,
+) -> None:
+    # Given
+    key = "my_feature"
+    default_value = "default"
+
+    provider = FlagsmithProvider(mock_flagsmith_client)
+    mock_flagsmith_client.get_environment_flags.return_value = Flags({})
+
+    # When
+    with pytest.raises(FlagNotFoundError) as e:
+        provider.resolve_string_details(key, default_value=default_value)
+
+    # Then
+    assert e.value.error_code == ErrorCode.FLAG_NOT_FOUND
+    assert e.value.error_message == f"Flag '{key}' was not found."
+
+
 def test_identity_flags_are_used_if_targeting_key_provided(
     mock_flagsmith_client: MagicMock,
 ) -> None:


### PR DESCRIPTION
Fixes https://github.com/Flagsmith/flagsmith-openfeature-provider-python/issues/33